### PR TITLE
Update architect-orb to 2.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  architect: giantswarm/architect@0.4.5
+  architect: giantswarm/architect@2.1.0
 
 version: 2.1
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  architect: giantswarm/architect@2.1.0
+  architect: giantswarm/architect@2.3.0
 
 version: 2.1
 jobs:

--- a/helm/sudo-azure-operator/Chart.yaml
+++ b/helm/sudo-azure-operator/Chart.yaml
@@ -1,3 +1,6 @@
 apiVersion: v1
 name: sudo-azure-operator
 version: [[ .Version ]]
+appVersion: "[[ .AppVersion ]]"
+description: sudo-azure-operator manages Azure resources that require higher-level roles, so that permissions required by the azure-operator can be reduced to resource group level.
+home: https://github.com/giantswarm/sudo-azure-operator

--- a/helm/sudo-azure-operator/templates/pull-secret.yaml
+++ b/helm/sudo-azure-operator/templates/pull-secret.yaml
@@ -5,5 +5,8 @@ type: kubernetes.io/dockerconfigjson
 metadata:
   name: {{ tpl .Values.resource.pullSecret.name . }}
   namespace: {{ tpl .Values.resource.pullSecret.namespace . }}
-data:
-  .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}
+stringData:
+  dockerhub-secret.yaml: |
+    service:
+      registry:
+        dockerhubToken: {{ .Values.Installation.V1.Secret.Registry.Dockerhub.Token | quote }}


### PR DESCRIPTION
Update architect-orb to 2.1.0 which will use giantswarm.github.io as catalog base url. The old behaviour was to use giantswarm.github.com which will be deprecated in april by GitHub. Towards giantswarm/giantswarm#15898